### PR TITLE
feat: first-session milestones (#147)

### DIFF
--- a/src/components/DebugConsole.tsx
+++ b/src/components/DebugConsole.tsx
@@ -272,6 +272,18 @@ const DebugConsole: React.FC = () => {
           >
             Reset Topology
           </button>
+          <button 
+            onClick={() => {
+              if(confirm("Clear all saved data and reload?")) {
+                localStorage.removeItem('isp-game-v1')
+                localStorage.removeItem('isp-tech-v1')
+                window.location.reload()
+              }
+            }}
+            className="w-full py-1.5 bg-red-900/20 border border-red-900/40 text-red-600 text-[9px] uppercase hover:bg-red-900/30 transition-all font-bold"
+          >
+            Clear Save Data
+          </button>
         </div>
       </div>
 

--- a/src/store/useISPStore.test.ts
+++ b/src/store/useISPStore.test.ts
@@ -172,3 +172,53 @@ describe('Debt Escalation System', () => {
         expect(state.emergencyLoanTicksRemaining).toBe(0);
     });
 });
+
+describe('awardMilestone', () => {
+    beforeEach(() => {
+        useISPStore.getState().resetTopology();
+        useISPStore.setState({ isGodMode: false, claimedMilestones: [], money: 5000 });
+    });
+
+    it('should award milestone once and add bonus to money', () => {
+        useISPStore.getState().awardMilestone('test_ms', 100, 'Test milestone');
+        const state = useISPStore.getState();
+        expect(state.claimedMilestones).toContain('test_ms');
+        expect(state.money).toBe(5100);
+    });
+
+    it('should add a log entry when milestone is awarded', () => {
+        useISPStore.getState().awardMilestone('test_ms', 100, 'Test milestone');
+        const state = useISPStore.getState();
+        expect(state.logs[0]).toContain('[MILESTONE]');
+        expect(state.logs[0]).toContain('Test milestone');
+    });
+
+    it('should not award milestone twice', () => {
+        useISPStore.getState().awardMilestone('test_ms', 100, 'Test milestone');
+        const moneyAfterFirst = useISPStore.getState().money;
+        useISPStore.getState().awardMilestone('test_ms', 100, 'Test milestone');
+        expect(useISPStore.getState().money).toBe(moneyAfterFirst);
+    });
+
+    it('should skip milestone in God Mode', () => {
+        useISPStore.setState({ isGodMode: true });
+        useISPStore.getState().awardMilestone('test_ms', 100, 'Test milestone');
+        const state = useISPStore.getState();
+        expect(state.claimedMilestones).not.toContain('test_ms');
+        expect(state.money).toBe(5000);
+    });
+
+    it('first_link milestone fires after connectNodes', () => {
+        useISPStore.setState({ isGodMode: true, claimedMilestones: [] });
+        // God Mode — milestone should NOT fire
+        useISPStore.getState().connectNodes('0', 'l1-a');
+        expect(useISPStore.getState().claimedMilestones).not.toContain('first_link');
+
+        // Normal mode — milestone fires on first link
+        useISPStore.getState().resetTopology();
+        useISPStore.setState({ isGodMode: false, claimedMilestones: [], money: 5000 });
+        useISPStore.getState().connectNodes('0', 'l1-a');
+        expect(useISPStore.getState().claimedMilestones).toContain('first_link');
+        expect(useISPStore.getState().money).toBeGreaterThan(5000 - 500 /* cost */ + 250 /* bonus */ - 50 /* tolerance */);
+    });
+});

--- a/src/store/useISPStore.ts
+++ b/src/store/useISPStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 import eraConfigData from '../config/eraConfig.json';
 import { NODE_TEMPLATES } from '../config/nodeRegistry';
 import type { ISPNodeType } from '../config/nodeRegistry';
@@ -157,7 +158,9 @@ interface ISPStore {
   isNonCore: (id: string) => boolean;
 }
 
-export const useISPStore = create<ISPStore>((set, get) => ({
+export const useISPStore = create<ISPStore>()(
+  persist(
+    (set, get) => ({
   money: 5000,
   techPoints: 50,
   tpAccumulator: 0,
@@ -627,4 +630,22 @@ export const useISPStore = create<ISPStore>((set, get) => ({
       { id: 'l1-b', name: 'LOCAL TERMINAL B', x: DEFAULT_START.x - 15, y: DEFAULT_START.y + 15, bandwidth: 56, baseBandwidth: 56, traffic: 0, level: 1, layer: 1, type: 'terminal', health: 100, isCore: true },
     ]
   })),
-}));
+  }),
+    {
+      name: 'isp-game-v1',
+      partialize: (state) => ({
+        nodes: state.nodes,
+        links: state.links,
+        money: state.money,
+        techPoints: state.techPoints,
+        tpAccumulator: state.tpAccumulator,
+        totalData: state.totalData,
+        currentEra: state.currentEra,
+        debtTier: state.debtTier,
+        emergencyLoanUsed: state.emergencyLoanUsed,
+        emergencyLoanActive: state.emergencyLoanActive,
+        emergencyLoanTicksRemaining: state.emergencyLoanTicksRemaining,
+      }),
+    }
+  )
+);

--- a/src/store/useISPStore.ts
+++ b/src/store/useISPStore.ts
@@ -97,6 +97,7 @@ interface ISPStore {
   selectedNodeId: string | null;
   isLinking: boolean;
   isGodMode: boolean;
+  claimedMilestones: string[];
   tickRate: number;
   networkHealth: number;
   avgLatency: number;
@@ -156,6 +157,7 @@ interface ISPStore {
   sellNode: (nodeId: string) => void;
   takeEmergencyLoan: () => void;
   isNonCore: (id: string) => boolean;
+  awardMilestone: (milestoneId: string, bonus: number, message: string) => void;
 }
 
 export const useISPStore = create<ISPStore>()(
@@ -191,6 +193,7 @@ export const useISPStore = create<ISPStore>()(
   emergencyLoanUsed: false,
   emergencyLoanActive: false,
   emergencyLoanTicksRemaining: 0,
+  claimedMilestones: [],
 
   setActiveDevNodeType: (type: string) => {
     if (NODE_TEMPLATES.some(t => t.type === type)) {
@@ -321,6 +324,7 @@ export const useISPStore = create<ISPStore>()(
       }
 
       const allLogs = [...debtLogs, ...newLogs];
+      const newTotalData = state.totalData + Math.floor(totalLoad * (state.tickRate / 1000) * 125);
 
       set({
         nodes: debtNodes,
@@ -329,7 +333,7 @@ export const useISPStore = create<ISPStore>()(
         debtTier: newTier,
         emergencyLoanActive: loanActive,
         emergencyLoanTicksRemaining: loanTicks,
-        totalData: state.totalData + Math.floor(totalLoad * (state.tickRate / 1000) * 125),
+        totalData: newTotalData,
         techPoints: state.techPoints + tpToAdd,
         tpAccumulator: newTpAccumulator - tpToAdd,
         networkHealth,
@@ -337,6 +341,13 @@ export const useISPStore = create<ISPStore>()(
         activePaths: e.data.activePaths || {},
         logs: allLogs.length > 0 ? [...allLogs, ...state.logs].slice(0, 20) : state.logs
       });
+
+      if (revenue > 0) {
+        get().awardMilestone('first_revenue', 100, 'First paying customer. Keep the packets flowing.');
+      }
+      if (newTotalData >= 1024) {
+        get().awardMilestone('first_kb', 500, 'First kilobyte delivered. Your network is working.');
+      }
     };
     set({ worker });
   },
@@ -479,6 +490,8 @@ export const useISPStore = create<ISPStore>()(
       links: [...s.links, newLink],
       logs: [`SYS_LINK: NEW_LINK ${type.toUpperCase()} [BW: ${bandwidth}] [COST: $${cost}]`, ...s.logs].slice(0, 15)
     }));
+
+    get().awardMilestone('first_link', 250, 'First connection established. Revenue coming online.');
   },
 
   removeNode: (id: string) => {
@@ -614,6 +627,17 @@ export const useISPStore = create<ISPStore>()(
     };
   }),
 
+  awardMilestone: (milestoneId: string, bonus: number, message: string) => {
+    const state = get();
+    if (state.claimedMilestones.includes(milestoneId)) return;
+    if (state.isGodMode) return;
+    set({
+      claimedMilestones: [...state.claimedMilestones, milestoneId],
+      money: state.money + bonus,
+      logs: [`[MILESTONE] ${message} +$${bonus}`, ...state.logs].slice(0, 20),
+    });
+  },
+
   toggleGodMode: () => set((state) => ({ isGodMode: !state.isGodMode })),
   setTickRate: (rate) => set({ tickRate: rate }),
   resetTopology: () => set((state) => ({
@@ -645,6 +669,7 @@ export const useISPStore = create<ISPStore>()(
         emergencyLoanUsed: state.emergencyLoanUsed,
         emergencyLoanActive: state.emergencyLoanActive,
         emergencyLoanTicksRemaining: state.emergencyLoanTicksRemaining,
+        claimedMilestones: state.claimedMilestones,
       }),
     }
   )

--- a/src/store/useTechStore.ts
+++ b/src/store/useTechStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 import techTreeData from '../config/techTreeConfig.json';
 
 export interface TechModifiers {
@@ -52,7 +53,9 @@ interface TechStore {
   resetTechs: () => void;
 }
 
-export const useTechStore = create<TechStore>((set, get) => ({
+export const useTechStore = create<TechStore>()(
+  persist(
+    (set, get) => ({
   unlockedTechIds: ['copper_standard', 'manual_switching'], 
   activeTechIds: ['copper_standard'], 
 
@@ -151,7 +154,16 @@ export const useTechStore = create<TechStore>((set, get) => ({
       activeTechIds: ['copper_standard']
     });
   }
-}));
+}),
+    {
+      name: 'isp-tech-v1',
+      partialize: (state) => ({
+        unlockedTechIds: state.unlockedTechIds,
+        activeTechIds: state.activeTechIds,
+      }),
+    }
+  )
+);
 
 // Helper selector for nodes
 export const getEffectiveBandwidth = (node: { bandwidth: number }) => {


### PR DESCRIPTION
Implements one-time milestone rewards for new players.

**Changes:**
- First link: +$250
- First revenue: +$100
- First KB delivered: +$500
- Persisted with localStorage
- Respects God Mode
- 32/32 tests passing

**Testing:**
Clear save → build link → see milestone log → reload → milestone doesn't fire again

Closes #147